### PR TITLE
Documentation rules

### DIFF
--- a/spectral-api.yml
+++ b/spectral-api.yml
@@ -10,3 +10,4 @@ rules:
   description-is-mandatory: warn
   info-description: error
   contact-information: error
+  path-description: error

--- a/spectral-api.yml
+++ b/spectral-api.yml
@@ -8,7 +8,7 @@ rules:
   http-verbs-should-be-used: warn
   no-http-verbs-in-resources: warn
   description-is-mandatory: warn
-  info-description: error
-  contact-information: error
-  path-description: error
-  path-dto-reference: error
+  info-description: warn
+  contact-information: warn
+  path-description: warn
+  path-dto-reference: warn

--- a/spectral-api.yml
+++ b/spectral-api.yml
@@ -11,3 +11,4 @@ rules:
   info-description: error
   contact-information: error
   path-description: error
+  path-dto-reference: error

--- a/spectral-api.yml
+++ b/spectral-api.yml
@@ -8,3 +8,5 @@ rules:
   http-verbs-should-be-used: warn
   no-http-verbs-in-resources: warn
   description-is-mandatory: warn
+  info-description: error
+  contact-information: error

--- a/spectral-bff.yml
+++ b/spectral-bff.yml
@@ -11,3 +11,4 @@ rules:
   info-description: error
   contact-information: error
   path-description: error
+  path-dto-reference: error

--- a/spectral-bff.yml
+++ b/spectral-bff.yml
@@ -8,3 +8,5 @@ rules:
   http-verbs-should-be-used: info
   no-http-verbs-in-resources: info
   description-is-mandatory: info
+  info-description: error
+  contact-information: error

--- a/spectral-bff.yml
+++ b/spectral-bff.yml
@@ -10,3 +10,4 @@ rules:
   description-is-mandatory: info
   info-description: error
   contact-information: error
+  path-description: error

--- a/spectral-bff.yml
+++ b/spectral-bff.yml
@@ -8,7 +8,7 @@ rules:
   http-verbs-should-be-used: info
   no-http-verbs-in-resources: info
   description-is-mandatory: info
-  info-description: error
-  contact-information: error
-  path-description: error
-  path-dto-reference: error
+  info-description: info
+  contact-information: info
+  path-description: info
+  path-dto-reference: info

--- a/spectral-legacy.yml
+++ b/spectral-legacy.yml
@@ -10,3 +10,4 @@ rules:
   description-is-mandatory: info
   info-description: warn
   contact-information: warn
+  path-description: warn

--- a/spectral-legacy.yml
+++ b/spectral-legacy.yml
@@ -8,3 +8,5 @@ rules:
   http-verbs-should-be-used: info
   no-http-verbs-in-resources: info
   description-is-mandatory: info
+  info-description: warn
+  contact-information: warn

--- a/spectral-legacy.yml
+++ b/spectral-legacy.yml
@@ -11,3 +11,4 @@ rules:
   info-description: warn
   contact-information: warn
   path-description: warn
+  path-dto-reference: warn

--- a/spectral-legacy.yml
+++ b/spectral-legacy.yml
@@ -2,13 +2,13 @@ extends:
   - https://raw.githubusercontent.com/SchwarzIT/api-linter-rules/main/spectral.yml
 rules:
   operation-tag-defined: off
-  path-must-match-api-standards: info
-  servers-must-match-api-standards: info
-  common-responses-unauthorized: info
-  http-verbs-should-be-used: info
-  no-http-verbs-in-resources: info
-  description-is-mandatory: info
-  info-description: warn
-  contact-information: warn
-  path-description: warn
-  path-dto-reference: warn
+  path-must-match-api-standards: hint
+  servers-must-match-api-standards: hint
+  common-responses-unauthorized: hint
+  http-verbs-should-be-used: hint
+  no-http-verbs-in-resources: hint
+  description-is-mandatory: hint
+  info-description: hint
+  contact-information: hint
+  path-description: hint
+  path-dto-reference: hint

--- a/spectral.yml
+++ b/spectral.yml
@@ -75,3 +75,29 @@ rules:
     then:
       - field: description
         function: truthy
+
+  info-description:
+    description: Every API must have a global description
+    message: "OpenAPI object info `description` must be present and at least 100 chars long."
+    severity: error
+    given: $.info
+    then:
+      - field: description
+        function: truthy
+      - field: description
+        function: length
+        functionOptions:
+          min: 100
+
+  contact-information:
+    description: Every API must have a contact containing name, email and a url
+    message: "{{description}}; property {{property}} is missing"
+    severity: error
+    given: $.info.contact
+    then:
+      - field: name
+        function: truthy
+      - field: email
+        function: truthy
+      - field: url
+        function: truthy

--- a/spectral.yml
+++ b/spectral.yml
@@ -110,3 +110,13 @@ rules:
     then:
       - field: description
         function: truthy
+
+  path-dto-reference:
+    description: DTOs should be used to specify the schema of a request / response
+    message: "{{description}}; property {{property}} is missing"
+    severity: error
+    given: $.components.schemas
+    then:
+      - function: length
+        functionOptions:
+          min: 1

--- a/spectral.yml
+++ b/spectral.yml
@@ -101,3 +101,12 @@ rules:
         function: truthy
       - field: url
         function: truthy
+
+  path-description:
+    description: Each path of an API must have a description
+    message: "{{description}}; property `description` is missing for path {{path}}"
+    severity: error
+    given: $.paths[?(!@property.match(/well-known/ig))]
+    then:
+      - field: description
+        function: truthy


### PR DESCRIPTION
Created 7 new rules to ensure a good documentation inside an OpenAPI spec:

1. API spec must have info section
2. API spec must have info.title
3. API spec must have info.description with a minimum of 100 chars
4. API spec must have info.contact section
5. API spec must have contact.name, contact.url, contact.email
6. API spec must have a description for each path(s)
7. API spec must use DTO schemas