### PR TITLE
Endpoint rules

### DIFF
--- a/spectral-api.yml
+++ b/spectral-api.yml
@@ -9,3 +9,4 @@ rules:
   no-http-verbs-in-resources: warn
   description-is-mandatory: warn
   must-have-path: error
+  must-have-response-body: error

--- a/spectral-api.yml
+++ b/spectral-api.yml
@@ -8,3 +8,4 @@ rules:
   http-verbs-should-be-used: warn
   no-http-verbs-in-resources: warn
   description-is-mandatory: warn
+  must-have-path: error

--- a/spectral-api.yml
+++ b/spectral-api.yml
@@ -12,3 +12,4 @@ rules:
   must-have-response-body: warn
   must-have-content-type: warn
   must-define-example-schema: warn
+  path-must-specify-tags: warn

--- a/spectral-api.yml
+++ b/spectral-api.yml
@@ -10,3 +10,4 @@ rules:
   description-is-mandatory: warn
   must-have-path: warn
   must-have-response-body: warn
+  must-have-content-type: warn

--- a/spectral-api.yml
+++ b/spectral-api.yml
@@ -11,3 +11,4 @@ rules:
   must-have-path: warn
   must-have-response-body: warn
   must-have-content-type: warn
+  must-define-example-schema: warn

--- a/spectral-api.yml
+++ b/spectral-api.yml
@@ -8,5 +8,5 @@ rules:
   http-verbs-should-be-used: warn
   no-http-verbs-in-resources: warn
   description-is-mandatory: warn
-  must-have-path: error
-  must-have-response-body: error
+  must-have-path: warn
+  must-have-response-body: warn

--- a/spectral-bff.yml
+++ b/spectral-bff.yml
@@ -12,3 +12,4 @@ rules:
   must-have-response-body: info
   must-have-content-type: info
   must-define-example-schema: info
+  path-must-specify-tags: info

--- a/spectral-bff.yml
+++ b/spectral-bff.yml
@@ -8,3 +8,4 @@ rules:
   http-verbs-should-be-used: info
   no-http-verbs-in-resources: info
   description-is-mandatory: info
+  must-have-path: error

--- a/spectral-bff.yml
+++ b/spectral-bff.yml
@@ -10,3 +10,4 @@ rules:
   description-is-mandatory: info
   must-have-path: info
   must-have-response-body: info
+  must-have-content-type: info

--- a/spectral-bff.yml
+++ b/spectral-bff.yml
@@ -11,3 +11,4 @@ rules:
   must-have-path: info
   must-have-response-body: info
   must-have-content-type: info
+  must-define-example-schema: info

--- a/spectral-bff.yml
+++ b/spectral-bff.yml
@@ -9,3 +9,4 @@ rules:
   no-http-verbs-in-resources: info
   description-is-mandatory: info
   must-have-path: error
+  must-have-response-body: error

--- a/spectral-bff.yml
+++ b/spectral-bff.yml
@@ -8,5 +8,5 @@ rules:
   http-verbs-should-be-used: info
   no-http-verbs-in-resources: info
   description-is-mandatory: info
-  must-have-path: error
-  must-have-response-body: error
+  must-have-path: info
+  must-have-response-body: info

--- a/spectral-legacy.yml
+++ b/spectral-legacy.yml
@@ -2,11 +2,11 @@ extends:
   - https://raw.githubusercontent.com/SchwarzIT/api-linter-rules/main/spectral.yml
 rules:
   operation-tag-defined: off
-  path-must-match-api-standards: info
-  servers-must-match-api-standards: info
-  common-responses-unauthorized: info
-  http-verbs-should-be-used: info
-  no-http-verbs-in-resources: info
-  description-is-mandatory: info
-  must-have-path: warn
-  must-have-response-body: warn
+  path-must-match-api-standards: hint
+  servers-must-match-api-standards: hint
+  common-responses-unauthorized: hint
+  http-verbs-should-be-used: hint
+  no-http-verbs-in-resources: hint
+  description-is-mandatory: hint
+  must-have-path: hint
+  must-have-response-body: hint

--- a/spectral-legacy.yml
+++ b/spectral-legacy.yml
@@ -10,3 +10,4 @@ rules:
   description-is-mandatory: hint
   must-have-path: hint
   must-have-response-body: hint
+  must-have-content-type: hint

--- a/spectral-legacy.yml
+++ b/spectral-legacy.yml
@@ -8,3 +8,4 @@ rules:
   http-verbs-should-be-used: info
   no-http-verbs-in-resources: info
   description-is-mandatory: info
+  must-have-path: warn

--- a/spectral-legacy.yml
+++ b/spectral-legacy.yml
@@ -9,3 +9,4 @@ rules:
   no-http-verbs-in-resources: info
   description-is-mandatory: info
   must-have-path: warn
+  must-have-response-body: warn

--- a/spectral-legacy.yml
+++ b/spectral-legacy.yml
@@ -12,3 +12,4 @@ rules:
   must-have-response-body: hint
   must-have-content-type: hint
   must-define-example-schema: hint
+  path-must-specify-tags: hint

--- a/spectral-legacy.yml
+++ b/spectral-legacy.yml
@@ -11,3 +11,4 @@ rules:
   must-have-path: hint
   must-have-response-body: hint
   must-have-content-type: hint
+  must-define-example-schema: hint

--- a/spectral.yml
+++ b/spectral.yml
@@ -75,3 +75,15 @@ rules:
     then:
       - field: description
         function: truthy
+
+  ## checks that the api has at least one path
+  must-have-path:
+    description: Every API must have at least one path
+    message: "{{description}}; property `paths` is empty"
+    severity: error
+    given: $
+    then:
+      - field: paths
+        function: length
+        functionOptions:
+          min: 1

--- a/spectral.yml
+++ b/spectral.yml
@@ -90,7 +90,7 @@ rules:
 
   must-have-response-body:
     description: Every route returning a http status code of 200 or 201 should have a response body defined
-    message: "{{description}}; property {{property}} is missing at path {{path}}"
+    message: "{{description}}; property {{property}} is missing at path: {{path}}"
     severity: error
     given: $.paths[?(!@property.match(/well-known/ig))]..responses[200,201]
     then:
@@ -98,3 +98,14 @@ rules:
         function: truthy
       - field: description
         function: truthy
+
+  must-have-content-type:
+    description: Every response should specify its content type
+    message: "{{description}}; property {{property}} is missing or not a valid content-type"
+    severity: error
+    given: $.paths[?(!@property.match(/well-known/ig))]..content
+    then:
+      - field: "@key"
+        function: pattern
+        functionOptions:
+          match: "/"

--- a/spectral.yml
+++ b/spectral.yml
@@ -121,3 +121,14 @@ rules:
           properties:
             - example
             - examples
+
+  path-must-specify-tags:
+    description: Every route should specify at least one tag it belongs to
+    message: "{{description}}; property tags is missing at: {{path}}"
+    severity: error
+    given: $.paths[?(!@property.match(/well-known/ig))].*
+    then:
+      - field: tags
+        function: length
+        functionOptions:
+          min: 1

--- a/spectral.yml
+++ b/spectral.yml
@@ -87,3 +87,14 @@ rules:
         function: length
         functionOptions:
           min: 1
+
+  must-have-response-body:
+    description: Every route returning a http status code of 200 or 201 should have a response body defined
+    message: "{{description}}; property {{property}} is missing at path {{path}}"
+    severity: error
+    given: $.paths[?(!@property.match(/well-known/ig))]..responses[200,201]
+    then:
+      - field: content
+        function: truthy
+      - field: description
+        function: truthy

--- a/spectral.yml
+++ b/spectral.yml
@@ -109,3 +109,15 @@ rules:
         function: pattern
         functionOptions:
           match: "/"
+
+  must-define-example-schema:
+    description: Every DTO should define at least one example
+    message: "{{description}}; DTO is lacking an example {{path}}"
+    severity: error
+    given: $.paths[?(!@property.match(/well-known/ig))]..content.*
+    then:
+      - function: xor
+        functionOptions:
+          properties:
+            - example
+            - examples


### PR DESCRIPTION
Added the following rules:

1. API spec must have at least one path(s)
2. API spec endpoint (paths) must have defined response body for HTTP.ResponseCode 200 OR 201
3. API spec endpoint (paths) must have defined a content type 
4. API spec endpoint (paths) must have defined example schema
5. API spec endpoint (paths) name must include set tags