### PR TITLE
Removed a redundant rule requiring a description for every route

### DIFF
--- a/spectral-api.yml
+++ b/spectral-api.yml
@@ -10,5 +10,4 @@ rules:
   description-is-mandatory: warn
   info-description: warn
   contact-information: warn
-  path-description: warn
   path-dto-reference: warn

--- a/spectral-bff.yml
+++ b/spectral-bff.yml
@@ -10,5 +10,4 @@ rules:
   description-is-mandatory: info
   info-description: info
   contact-information: info
-  path-description: info
   path-dto-reference: info

--- a/spectral-legacy.yml
+++ b/spectral-legacy.yml
@@ -10,5 +10,4 @@ rules:
   description-is-mandatory: hint
   info-description: hint
   contact-information: hint
-  path-description: hint
   path-dto-reference: hint

--- a/spectral.yml
+++ b/spectral.yml
@@ -102,15 +102,6 @@ rules:
       - field: url
         function: truthy
 
-  path-description:
-    description: Each path of an API must have a description
-    message: "{{description}}; property `description` is missing for path {{path}}"
-    severity: error
-    given: $.paths[?(!@property.match(/well-known/ig))]
-    then:
-      - field: description
-        function: truthy
-
   path-dto-reference:
     description: DTOs should be used to specify the schema of a request / response
     message: "{{description}}; property {{property}} is missing"


### PR DESCRIPTION
Rule `path-description` was the same as `description-is-mandatory`