### PR TITLE
Fixed the CODEOWNERS file to match the format of GitHub

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-@sn0wbi
-@markbrockhoff
+* @sn0wbi @markbrockhoff


### PR DESCRIPTION
Changed the formating of the CODEOWNERS file to match the standard described by GitHub: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax