### PR TITLE
Disable http-verbs-should-be-used for bffs

### DIFF
--- a/spectral-bff.yml
+++ b/spectral-bff.yml
@@ -5,7 +5,7 @@ rules:
   path-must-match-api-standards: off # Rule is still under discussion and therefore disabled
   servers-must-match-api-standards: off # Rule is still under discussion and therefore disabled
   common-responses-unauthorized: hint
-  http-verbs-should-be-used: info
+  http-verbs-should-be-used: off
   no-http-verbs-in-resources: info
   path-description-is-mandatory: info
   info-description: info


### PR DESCRIPTION
Closes #27 

This PR disables the rule http-verbs-should-be-used for apis of type bff as it is a common usecase to not implement unused methods in those apis. Hover, it will stay enabled for product apis to improve their quality and reusability.