### PR TITLE
chore(must-define-example-schema): Weaken strictness of rule

### DIFF
--- a/rules/endpoint/must-define-example-schema.spec.ts
+++ b/rules/endpoint/must-define-example-schema.spec.ts
@@ -30,31 +30,15 @@ describe("must-define-example-schema", () => {
     expect(result[0].code).toEqual("must-define-example-schema");
   });
 
-  it("ignores paths unde /well-known/", async () => {
-    const result = await spectral.run(getTestSpec({ example: true }, "/well-known/api/something"));
-    expect(result).toHaveLength(0);
-  });
-
-  const getTestSpec = (examples: { example?: boolean; examples?: boolean }, path = "/api/some/path"): string =>
+  const getTestSpec = (examples: { example?: boolean; examples?: boolean }): string =>
     JSON.stringify(
       {
-        paths: {
-          [path]: {
-            post: {
-              responses: {
-                "201": {
-                  content: {
-                    "application/json": {
-                      ...examples,
-                    },
-                  },
-                },
-                "400": {
-                  description: "",
-                },
-              },
-            },
-          },
+        components: {
+          schemas: {
+            ExampleDTO: {
+              ...examples
+            }
+          }
         },
       },
       null,

--- a/rules/endpoint/must-define-example-schema.yml
+++ b/rules/endpoint/must-define-example-schema.yml
@@ -5,7 +5,7 @@ rules:
     description: Every DTO must define at least one example
     message: "{{description}}; DTO is lacking an example {{path}}"
     severity: error
-    given: $.paths[?(!@property.match(/well-known/ig))]..content.*
+    given: $.components.schemas.*
     then:
       - function: xor
         functionOptions:


### PR DESCRIPTION
Weaken strictness of rule to only require examples for DTOs

Before a example was required for every key "content" which was quiet strict as examples can also be placed at attribute level. Now the rule only enforces a top-level example for every global DTO, thereby also matching the error message. It would be possible to enforce the usage of only DTOs for request bodys and responses in the future to further improve this rule.