### PR TITLE
Fixed: path-must-specify-tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode
 demo*
 node_modules
+pnpm-lock.yaml
 wiki
 .npmrc
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@stoplight/spectral-core": "^1.18.3",
+    "@stoplight/spectral-runtime": "^1.1.2",
     "@stoplight/spectral-ruleset-bundler": "^1.5.2",
     "@types/jest": "^29.5.3",
     "jest": "^29.6.1",

--- a/rules/endpoint/path-must-specify-tags.spec.ts
+++ b/rules/endpoint/path-must-specify-tags.spec.ts
@@ -25,6 +25,11 @@ describe("path-must-specify-tags", () => {
     expect(result[0].code).toEqual("path-must-specify-tags");
   });
 
+  it("do not fail if the keywords for http methods are used in components", async () => {
+    const result = await spectral.run(getComponentTestSpec());
+    expect(result).toHaveLength(0);
+  });
+
   it("ignores paths under the well-known route", async () => {
     const result = await spectral.run(getTestSpec(undefined, "/well-known/health"));
     expect(result).toHaveLength(0);
@@ -60,4 +65,115 @@ describe("path-must-specify-tags", () => {
         },
       },
     });
+
+const getComponentTestSpec = (tags?: string[], path = "/api/some/path") =>
+  JSON.stringify({
+    "openapi": "3.0.2",
+    "info": {
+      "title": "Sometest",
+      "version": "0.1",
+      "description": "This example shows that options will give a false positive in the schema ShowMe an false positive warning",
+      "contact": {
+        "email": "lucas@maciuga.de",
+        "name": "Lucas Maciuga",
+        "url": "https://have.none"
+      }
+    },
+    "servers": [
+      {
+        "url": "https://test.api.schwarz"
+      }
+    ],
+    "tags": [
+      {
+        "name": "SomeTag",
+        "description": "some description"
+      }
+    ],
+    "paths": {
+      "/twin/api/v1/somethings": {
+        "get": {
+          "operationId": "GetSomething",
+          "description": "hi test",
+          "tags": [
+            "SomeTag"
+          ],
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ShowMe"
+                  }
+                }
+              }
+            },
+            "401": {
+              "description": "Unauthorized"
+            }
+          }
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "Option": {
+          "type": "object",
+          "properties": {
+            "field1": {
+              "type": "string"
+            }
+          },
+          "example": {
+            "field1": "val1"
+          }
+        },
+        "ShowMe": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "object",
+              "properties": {
+                "get": {
+                  "type": "string"
+                },
+                "delete": {
+                  "type": "boolean"
+                },
+                "options": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Option"
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "example": {
+            "input": {
+              "options": [
+                {
+                  "field1": "val1"
+                },
+                {
+                  "field1": "val2"
+                },
+                {
+                  "field1": "val3"
+                },
+                {
+                  "field1": "val4"
+                },
+                {
+                  "field1": "val5"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  });
 });

--- a/rules/endpoint/path-must-specify-tags.yml
+++ b/rules/endpoint/path-must-specify-tags.yml
@@ -7,7 +7,7 @@ rules:
     severity: error
     formats:
       - oas3
-    given: $.paths[?(!@property.match(/well-known/ig))].[get,post,put,delete,patch,options,head,trace]
+    given: $.paths[?(!@property.match(/well-known/ig))][get,post,put,delete,patch,options,head,trace]
     then:
       - field: tags
         function: truthy


### PR DESCRIPTION
Hi,

I run into a bug in the path-must-specify-tags rule. If you define under schemas a model with a property that is named "get,post,put,delete,patch,options,head or trace" it will raise an error/warning.

I fixed it, by removing the 'dot' in the JSONPath under "given".
I wrote an additional test which will be raised when the dot is present in the given-selector.

Please check if the selector is correct - tested the selector with https://jsonpath.com/, but it gives me not the same result as the implementation of spectral.